### PR TITLE
Surround node names with double quotes in graphviz output.

### DIFF
--- a/src/DSGRN/Query/Graph.py
+++ b/src/DSGRN/Query/Graph.py
@@ -59,8 +59,8 @@ class Graph:
     Return graphviz string for graph
     """
     return 'digraph {' + \
-  '\n'.join([ self.vertexname[v] + '[label="' + self.label(v) + '";style="filled";fillcolor="' + self.color(v) + '"];' for v in self.vertices ]) + \
-   '\n' + '\n'.join([ self.vertexname[u]  + " -> " + self.vertexname[v]  + ';' for (u, v) in self.edges ]) + \
+  '\n'.join([ '"' + self.vertexname[v] + '" [label="' + self.label(v) + '";style="filled";fillcolor="' + self.color(v) + '"];' for v in self.vertices ]) + \
+   '\n' + '\n'.join([ '"' + self.vertexname[u]  + '" -> "' + self.vertexname[v]  + '";' for (u, v) in self.edges ]) + \
    '\n' + '}\n'
 
   def adjacencies(self, p):

--- a/src/DSGRN/Query/PosetOfExtrema.py
+++ b/src/DSGRN/Query/PosetOfExtrema.py
@@ -45,8 +45,8 @@ class PosetOfExtrema(Pattern):
     Return graphviz string for visualization
     """ 
     N = len(self.labels_)
-    gv_vertices = [ str(i) + ' [label="' + self.labels_[i] + '"];' for i in range(0,N) ]
-    gv_edges = [ str(u) + " -> " + str(v) + ';' for u in range(0,N) for v in self.poset_.children(u) ]
+    gv_vertices = [ '"' + str(i) + '" [label="' + self.labels_[i] + '"];' for i in range(0,N) ]
+    gv_edges = [ '"' + str(u) + '" -> "' + str(v) + '";' for u in range(0,N) for v in self.poset_.children(u) ]
     return 'digraph {\n' + '\n'.join(gv_vertices) + '\n' + '\n'.join(gv_edges) + '\n}\n'
 
 

--- a/src/DSGRN/_dsgrn/include/Parameter/Network.hpp
+++ b/src/DSGRN/_dsgrn/include/Parameter/Network.hpp
@@ -114,7 +114,7 @@ graphviz ( std::vector<std::string> const& theme ) const {
   result << "digraph {\n";
   result << "bgcolor = " << theme[0] << ";";
   for ( uint64_t i = 0; i < size (); ++ i ) {
-    result << name(i) << "[style=filled fillcolor=" << theme[1] << "];\n";
+    result << "\"" << name(i) << "\"" << " [style=filled fillcolor=" << theme[1] << "];\n";
   }
   std::string normalhead ("normal");
   std::string blunthead ("tee");
@@ -127,7 +127,7 @@ graphviz ( std::vector<std::string> const& theme ) const {
       for ( uint64_t source : part ) {
         // std::cout << "Checking type of edge from " << source << " to " << target << "\n";
         std::string head = interaction(source,target) ? normalhead : blunthead;
-        result << name(source) << " -> " << name(target) << "[color=" << theme[partnum+2] << " arrowhead=\"" << head << "\"];\n";
+        result << "\"" << name(source) << "\" -> \"" << name(target) << "\" [color=" << theme[partnum+2] << " arrowhead=\"" << head << "\"];\n";
       }
       ++ partnum;
       if ( partnum + 2 == theme . size () ) partnum = 0;


### PR DESCRIPTION
I am generating some networks from another tool that uses the `$` character in the node names. `$` is not allowed in an unquoted DOT node id, so the generated graphviz source will not be parsed by graphviz. I'd like to be able to map between my original structure and the DSGRN network. Escaping or pruning `$` or other unallowed characters might be possible for me, but surrounding the node names with double quotes is the easiest fix. There should be no difference between quoted and unquoted strings otherwise (see the DOT grammar [here](https://www.graphviz.org/doc/info/lang.html)):

> An ID is one of the following:
> • Any string of alphabetic ([a-zA-Z\200-\377]) characters, underscores ('_') or digits ([0-9]), not beginning with a digit;
> • a numeral [-]?(.[0-9]+ | [0-9]+(.[0-9]*)? );
> • any double-quoted string ("...") possibly containing escaped quotes (\")1;
> • an HTML string (<...>).
> An ID is just a string; the lack of quote characters in the first two forms is just for simplicity. There is no semantic difference between abc_2 and "abc_2", or between 2.34 and "2.34".

Example output before pull request:

    digraph {
    ...
    out [style=filled fillcolor=beige];
    $50 [style=filled fillcolor=beige];
    $50 -> out[color=black arrowhead="tee"];

Example output after pull request:

    digraph {
    ...
    "out" [style=filled fillcolor=beige];
    "$50" [style=filled fillcolor=beige];
    "$50" -> "out" [color=black arrowhead="tee"];
